### PR TITLE
Emotion-ferplus-8 implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 /.next/
 /out/
 
+# pycache
+/model-lab/app/__pycache__
+
 # production
 /build
 
@@ -34,6 +37,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+/model-lab/env
 
 # vercel
 .vercel

--- a/frontend/app/demo/page.jsx
+++ b/frontend/app/demo/page.jsx
@@ -10,7 +10,9 @@ export default function DemoPage() {
   const [preview, setPreview] = useState("");
   const [loading, setLoading] = useState(false);
   const [emotion, setEmotion] = useState("");
+  const [probabilities, setProbabilities] = useState(null);
   const [error, setError] = useState("");
+  const [modelOption, setModelOption] = useState("1");
 
   useEffect(() => {
     if (!file) {
@@ -24,6 +26,7 @@ export default function DemoPage() {
 
   const onFileChange = (e) => {
     setEmotion("");
+    setProbabilities(null);
     setError("");
     const f = (e.target.files && e.target.files[0]) || null;
     e.target.value = null;
@@ -46,6 +49,7 @@ export default function DemoPage() {
     e.preventDefault();
     setError("");
     setEmotion("");
+    setProbabilities(null);
 
     if (!file) {
       setError("No image selected.");
@@ -56,12 +60,14 @@ export default function DemoPage() {
     try {
       const fd = new FormData();
       fd.append("file", file);
+      fd.append("model_option", modelOption);
 
-      const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+      const API_URL =
+        process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
       const res = await fetch(`${API_URL}/predict`, {
-         method: "POST",
-         body: fd
-       })
+        method: "POST",
+        body: fd,
+      });
 
       if (!res.ok) {
         throw new Error(`Server error: ${res.status}`);
@@ -69,6 +75,7 @@ export default function DemoPage() {
 
       const result = await res.json();
       setEmotion(result.emotion);
+      setProbabilities(result.probabilities || null);
     } catch (err) {
       setError((err && err.message) || "Unknown error");
     } finally {
@@ -80,85 +87,106 @@ export default function DemoPage() {
     <div className="min-h-screen text-foreground relative bg-transparent">
       <AnimatedBackground />
       <div className="absolute inset-0 bg-background/80 backdrop-blur-[2px] -z-10" />
-        <HeroHeader />
-        <main className="pt-28 px-6 py-12 max-w-3xl mx-auto">
-          <h1 className="text-4xl font-bold mb-4">FaceFeel — Live Demo</h1>
-          <p className="text-muted-foreground mb-6">
-            Upload an image and see the predicted emotion.
-          </p>
+      <HeroHeader />
+      <main className="pt-28 px-6 py-12 max-w-3xl mx-auto">
+        <h1 className="text-4xl font-bold mb-4">FaceFeel — Live Demo</h1>
+        <p className="text-muted-foreground mb-6">
+          Upload an image and see the predicted emotion.
+        </p>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <input
-              id="file-input"
-              type="file"
-              accept="image/*"
-              onChange={onFileChange}
-              className="hidden"
-            />
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            id="file-input"
+            type="file"
+            accept="image/*"
+            onChange={onFileChange}
+            className="hidden"
+          />
 
-            <div className="flex items-center gap-3">
-              <label
-                htmlFor="file-input"
-                className="inline-flex items-center gap-2 rounded px-4 py-2 bg-primary text-primary-foreground cursor-pointer select-none"
-              >
-                Choose File
-                <MdUploadFile className="h-5 w-5" />
-              </label>
+          <div className="flex items-center gap-3">
+            <label
+              htmlFor="file-input"
+              className="inline-flex items-center gap-2 rounded px-4 py-2 bg-primary text-primary-foreground cursor-pointer select-none"
+            >
+              Choose File
+              <MdUploadFile className="h-5 w-5" />
+            </label>
 
-              <span className="text-sm text-muted-foreground truncate max-w-56">
-                {file ? file.name : "No file chosen"}
-              </span>
-            </div>
-
-            {preview && (
-              <div className="mt-2">
-                <img
-                  src={preview}
-                  alt="preview"
-                  className="w-full max-w-sm rounded-lg border border-border"
-                />
-              </div>
-            )}
-
-            <div className="flex items-center gap-3">
-              <button
-                type="submit"
-                disabled={loading}
-                className="rounded px-4 py-2 bg-primary text-primary-foreground font-semibold disabled:opacity-50 cursor-pointer"
-              >
-                {loading ? "Analyzing…" : "Predict"}
-              </button>
-
-              <button
-                type="button"
-                onClick={() => {
-                  setFile(null);
-                  setEmotion("");
-                  setError("");
-                }}
-                className="rounded px-3 py-2 border border-border text-sm cursor-pointer"
-              >
-                Reset
-              </button>
-            </div>
-          </form>
-
-          <div className="mt-6 space-y-4">
-            {error && (
-              <div className="rounded-md bg-destructive/10 border border-destructive/20 p-3 text-sm">
-                <strong>Error:</strong> {error}
-              </div>
-            )}
-
-            {emotion && (
-              <div className="rounded-md bg-emerald-500/10 border border-emerald-500/20 p-4">
-                <div className="text-xl font-semibold text-emerald-600 dark:text-emerald-400">
-                  Emotion: {emotion}
-                </div>
-              </div>
-            )}
+            <span className="text-sm text-muted-foreground truncate max-w-56">
+              {file ? file.name : "No file chosen"}
+            </span>
           </div>
-        </main>
+
+          {preview && (
+            <div className="mt-2">
+              <img
+                src={preview}
+                alt="preview"
+                className="w-full max-w-sm rounded-lg border border-border"
+              />
+            </div>
+          )}
+          <div className="mt-3">
+            <label className="text-sm font-medium mr-2">Model:</label>
+            <select
+              value={modelOption}
+              onChange={(e) => setModelOption(e.target.value)}
+              className="border border-border rounded px-2 py-1 bg-background"
+            >
+              <option value="1">ViT (HuggingFace)</option>
+              <option value="2">FER+ ONNX (Emotion Ferplus 8)</option>
+            </select>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={loading}
+              className="rounded px-4 py-2 bg-primary text-primary-foreground font-semibold disabled:opacity-50 cursor-pointer"
+            >
+              {loading ? "Analyzing…" : "Predict"}
+            </button>
+
+            <button
+              type="button"
+              onClick={() => {
+                setFile(null);
+                setEmotion("");
+                setError("");
+              }}
+              className="rounded px-3 py-2 border border-border text-sm cursor-pointer"
+            >
+              Reset
+            </button>
+          </div>
+        </form>
+
+        <div className="mt-6 space-y-4">
+          {error && (
+            <div className="rounded-md bg-destructive/10 border border-destructive/20 p-3 text-sm">
+              <strong>Error:</strong> {error}
+            </div>
+          )}
+
+          {emotion && (
+            <div className="rounded-md bg-emerald-500/10 border border-emerald-500/20 p-4">
+              <div className="text-xl font-semibold text-emerald-600 dark:text-emerald-400">
+                Emotion: {emotion}
+                {probabilities && (
+                  <ul className="mt-3 text-sm text-foreground space-y-1">
+                    {Object.entries(probabilities).map(([emo, pct]) => (
+                      <li key={emo}>
+                        <span className="font-medium">{emo}:</span>{" "}
+                        {pct.toFixed(2)}%
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </main>
     </div>
   );
 }

--- a/model-lab/README.md
+++ b/model-lab/README.md
@@ -53,19 +53,19 @@ curl -X POST "http://127.0.0.1:8000/predict" \
 ```
 
 Response example:
-
+*Response for an angry image for model 2*
 ```json
-{
-  "emotion": "happy",
-  "probabilities": {
-    "angry": 0.05,
-    "disgust": 0.02,
-    "fear": 0.03,
-    "happy": 0.78,
-    "sad": 0.04,
-    "surprise": 0.06,
-    "neutral": 0.02
-  }
+{"emotion":"anger",
+    "probabilities":{
+      "neutral":0.6067721843719482,
+      "happiness":0.128993958234787,
+      "surprise":0.22512483596801758,
+      "sadness":0.025787757709622383,
+      "anger":96.17911529541016,
+      "disgust":2.6538150310516357,
+      "fear":0.04158278927206993,
+      "contempt":0.13880738615989685
+    }
 }
 ```
 ## About Emotion-Ferplus-8 Model - 

--- a/model-lab/README.md
+++ b/model-lab/README.md
@@ -43,10 +43,13 @@ The API will start at:
 ### 4️⃣ Test the API
 
 You can test using `curl` or any tool like Postman:
-
+Give n = 1 or 2
+- 1 - For using the ViT model from hugging face
+- 2 - For using the Emotion-Ferplus-8 model as mentioned in onnx
 ```bash
 curl -X POST "http://127.0.0.1:8000/predict" \
-  -F "file=@face.jpg"
+  -F "file=@face.jpg" \
+  -F "model_option={n}"
 ```
 
 Response example:

--- a/model-lab/README.md
+++ b/model-lab/README.md
@@ -55,5 +55,16 @@ curl -X POST "http://127.0.0.1:8000/predict" \
 Response example:
 
 ```json
-{"emotion": "happy"}
+{
+  "emotion": "happy",
+  "probabilities": {
+    "angry": 0.05,
+    "disgust": 0.02,
+    "fear": 0.03,
+    "happy": 0.78,
+    "sad": 0.04,
+    "surprise": 0.06,
+    "neutral": 0.02
+  }
+}
 ```

--- a/model-lab/README.md
+++ b/model-lab/README.md
@@ -68,3 +68,20 @@ Response example:
   }
 }
 ```
+## About Emotion-Ferplus-8 Model - 
+*To be used if model conversion is needed in future versions*
+```
+  model = onnx.load(model_path)
+  converted_model = version_converter.convert_version(model, 12)
+  converted_path = model_path.replace("-8.onnx", "-12.onnx")
+  onnx.save_model(converted_model, converted_path)
+```
+
+In the `detect_face()` function if required to add more padding use this code - 
+```
+padding = int(0.2 * max(w, h))  # Increased from 10% to 20%
+x = max(0, x - padding)
+y = max(0, y - padding)
+w = min(gray.shape[1] - x, w + 2 * padding)
+h = min(gray.shape[0] - y, h + 2 * padding)
+```

--- a/model-lab/app/config.py
+++ b/model-lab/app/config.py
@@ -1,0 +1,3 @@
+VIT_MODEL_NAME = "trpakov/vit-face-expression"
+
+EMOTION_TABLE = {'neutral':0, 'happiness':1, 'surprise':2, 'sadness':3, 'anger':4, 'disgust':5, 'fear':6, 'contempt':7}

--- a/model-lab/app/main.py
+++ b/model-lab/app/main.py
@@ -1,13 +1,18 @@
-from fastapi import FastAPI, File, UploadFile, HTTPException
+from fastapi import FastAPI, File, UploadFile, HTTPException, Form
 from PIL import Image
 import io
 import os
-from app.model import predict_emotion
+from app.model import Model
+from pathlib import Path
 from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 load_dotenv()
 
 app = FastAPI(title="Face Sentiment API")
+
+# path to the model
+BASE_DIR = Path(__file__).resolve().parent.parent
+MODEL_PATH = BASE_DIR / "models"/ "onxx_models" / "emotion-ferplus-8.onnx"
 
 ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",")
 
@@ -19,12 +24,15 @@ app.add_middleware(
 )
 
 @app.post("/predict")
-async def predict(file: UploadFile = File(...)):
+async def predict(file: UploadFile = File(...), model_option: int = Form(1)):
     if not file.content_type.startswith("image/"):
         raise HTTPException(status_code=400, detail="File must be an image")
+    file_bytes = await file.read()
     try:
-        image = Image.open(io.BytesIO(await file.read()))
+        image = Image.open(io.BytesIO(file_bytes))
     except (OSError, ValueError) as err:
         raise HTTPException(status_code=400, detail="Invalid or corrupted image file") from err
-    emotion = predict_emotion(image)
-    return {"emotion": emotion}
+    emotion_model  = Model(model_path=MODEL_PATH, model_option=model_option)
+    emotion, prob = emotion_model.predict(pil_image=image)
+    
+    return {"emotion": emotion, "probabilities": prob}

--- a/model-lab/app/model.py
+++ b/model-lab/app/model.py
@@ -1,16 +1,96 @@
 from transformers import AutoFeatureExtractor, AutoModelForImageClassification
 from PIL import Image
+import numpy as np
+import onnxruntime as ort
+import onnx
+from onnx import version_converter
+import cv2
 import torch
 
-MODEL_NAME = "trpakov/vit-face-expression"
+class Model:
+    #emotion table for Emotion-ferplus
+    emotion_table = {'neutral':0, 'happiness':1, 'surprise':2, 'sadness':3, 'anger':4, 'disgust':5, 'fear':6, 'contempt':7}
+    prob_precentages={}
+    
+    VIT_MODEL_NAME = "trpakov/vit-face-expression"
 
-extractor = AutoFeatureExtractor.from_pretrained(MODEL_NAME)
-model = AutoModelForImageClassification.from_pretrained(MODEL_NAME)
+    extractor = AutoFeatureExtractor.from_pretrained(VIT_MODEL_NAME)
+    model = AutoModelForImageClassification.from_pretrained(VIT_MODEL_NAME)
+    
+    def __init__(self, model_path, model_option: int):
+        self.model_option = model_option
+        if (model_option == 2):
+            # To be used if model conversion is needed in future versions
+            # model = onnx.load(model_path)
+            # converted_model = version_converter.convert_version(model, 12)
+            # converted_path = model_path.replace("-8.onnx", "-12.onnx")
+            # onnx.save_model(converted_model, converted_path)
+            
+            # self.session = ort.InferenceSession(model_path)
+            self.face_cascade = cv2.CascadeClassifier(
+            cv2.data.haarcascades + 'haarcascade_frontalface_default.xml'
+            )
+            
+            self.net=cv2.dnn.readNetFromONNX(model_path)
+    
+    def detect_face(self, pil_image):
+        image = cv2.cvtColor(np.array(pil_image), cv2.COLOR_RGB2BGR)
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        faces = self.face_cascade.detectMultiScale(
+            gray,
+            scaleFactor=1.1,
+            minNeighbors=5,
+            minSize=(60, 60)
+        )
 
-def predict_emotion(image: Image.Image):
-    inputs = extractor(images=image, return_tensors="pt")
-    with torch.no_grad():
-        logits = model(**inputs).logits
-        predicted = logits.argmax(-1).item()
-    label = model.config.id2label[predicted]
-    return label
+        if len(faces) == 0:
+            return gray  
+
+        x,y,w,h = max(faces, key=lambda r: r[2] * r[3])
+        
+        # Extra padding around detected face (not required for now)
+        # padding = int(0.2 * max(w, h))  # Increased from 10% to 20%
+        # x = max(0, x - padding)
+        # y = max(0, y - padding)
+        # w = min(gray.shape[1] - x, w + 2 * padding)
+        # h = min(gray.shape[0] - y, h + 2 * padding)
+        
+        face = gray[y:y+h, x:x+w]
+        
+        return face
+              
+    def preprocess(self, pil_image):
+        gray_face = self.detect_face(pil_image=pil_image)
+        resized_face = cv2.resize(gray_face, (64, 64))
+        processed_face = resized_face.astype(np.float32)
+        processed_face = processed_face.reshape(1,1,64,64)
+        
+        return processed_face
+    
+    def predict(self, pil_image: Image.Image):
+        if (self.model_option == 1):
+            inputs = self.extractor(images=pil_image, return_tensors="pt")
+            with torch.no_grad():
+                logits = self.model(**inputs).logits
+                predicted = logits.argmax(-1).item()
+            label = self.model.config.id2label[predicted]
+            return label, self.prob_precentages
+
+        elif (self.model_option == 2):
+            processed_face = self.preprocess(pil_image=pil_image)
+
+            self.net.setInput(processed_face)
+            Output = self.net.forward()
+            
+            # calculatiing probabilities using softmax function                
+            expanded = np.exp(Output[0] - np.max(Output[0]))
+            probablities =  expanded / expanded.sum()
+
+            prob = np.squeeze(probablities)
+
+            for emotion, idx in sorted(self.emotion_table.items(), key=lambda x: x[1]):
+                self.prob_precentages[emotion] = float(prob[idx]*100)
+                
+            key = [k for k, v in self.emotion_table.items() if v == prob.argmax()][0]
+            label = key
+            return label, self.prob_precentages

--- a/model-lab/app/model.py
+++ b/model-lab/app/model.py
@@ -18,8 +18,10 @@ class Model:
     model = AutoModelForImageClassification.from_pretrained(VIT_MODEL_NAME)
     
     def __init__(self, model_path, model_option: int):
+        if (model_option not in (1,2)):
+            raise ValueError(f"model option must be 1 or 2, got {model_option}")
         self.model_option = model_option
-        if (model_option == 2):
+        if (self.model_option == 2):
             # To be used if model conversion is needed in future versions
             # model = onnx.load(model_path)
             # converted_model = version_converter.convert_version(model, 12)

--- a/model-lab/app/model.py
+++ b/model-lab/app/model.py
@@ -10,7 +10,7 @@ import torch
 class Model:
     #emotion table for Emotion-ferplus
     emotion_table = {'neutral':0, 'happiness':1, 'surprise':2, 'sadness':3, 'anger':4, 'disgust':5, 'fear':6, 'contempt':7}
-    prob_precentages={}
+    
     
     VIT_MODEL_NAME = "trpakov/vit-face-expression"
 
@@ -74,7 +74,7 @@ class Model:
                 logits = self.model(**inputs).logits
                 predicted = logits.argmax(-1).item()
             label = self.model.config.id2label[predicted]
-            return label, self.prob_precentages
+            return label, {}
 
         elif (self.model_option == 2):
             processed_face = self.preprocess(pil_image=pil_image)
@@ -87,10 +87,10 @@ class Model:
             probablities =  expanded / expanded.sum()
 
             prob = np.squeeze(probablities)
-
+            prob_precentages={}
             for emotion, idx in sorted(self.emotion_table.items(), key=lambda x: x[1]):
-                self.prob_precentages[emotion] = float(prob[idx]*100)
+                prob_precentages[emotion] = float(prob[idx]*100)
                 
             key = [k for k, v in self.emotion_table.items() if v == prob.argmax()][0]
             label = key
-            return label, self.prob_precentages
+            return label, prob_precentages

--- a/model-lab/app/model.py
+++ b/model-lab/app/model.py
@@ -6,29 +6,21 @@ import onnx
 from onnx import version_converter
 import cv2
 import torch
+from .config import VIT_MODEL_NAME, EMOTION_TABLE
 
 class Model:
-    #emotion table for Emotion-ferplus
-    emotion_table = {'neutral':0, 'happiness':1, 'surprise':2, 'sadness':3, 'anger':4, 'disgust':5, 'fear':6, 'contempt':7}
     
-    
-    VIT_MODEL_NAME = "trpakov/vit-face-expression"
-
-    extractor = AutoFeatureExtractor.from_pretrained(VIT_MODEL_NAME)
-    model = AutoModelForImageClassification.from_pretrained(VIT_MODEL_NAME)
     
     def __init__(self, model_path, model_option: int):
+        self.emotion_table=EMOTION_TABLE
         if (model_option not in (1,2)):
             raise ValueError(f"model option must be 1 or 2, got {model_option}")
         self.model_option = model_option
-        if (self.model_option == 2):
-            # To be used if model conversion is needed in future versions
-            # model = onnx.load(model_path)
-            # converted_model = version_converter.convert_version(model, 12)
-            # converted_path = model_path.replace("-8.onnx", "-12.onnx")
-            # onnx.save_model(converted_model, converted_path)
+        if (self.model_option==1):
+            self.extractor = AutoFeatureExtractor.from_pretrained(VIT_MODEL_NAME)
+            self.model = AutoModelForImageClassification.from_pretrained(VIT_MODEL_NAME)
             
-            # self.session = ort.InferenceSession(model_path)
+        if (self.model_option == 2):            
             self.face_cascade = cv2.CascadeClassifier(
             cv2.data.haarcascades + 'haarcascade_frontalface_default.xml'
             )
@@ -51,14 +43,6 @@ class Model:
             return gray  
 
         x,y,w,h = max(faces, key=lambda r: r[2] * r[3])
-        
-        # Extra padding around detected face (not required for now)
-        # padding = int(0.2 * max(w, h))  # Increased from 10% to 20%
-        # x = max(0, x - padding)
-        # y = max(0, y - padding)
-        # w = min(gray.shape[1] - x, w + 2 * padding)
-        # h = min(gray.shape[0] - y, h + 2 * padding)
-        
         face = gray[y:y+h, x:x+w]
         
         return face

--- a/model-lab/app/model.py
+++ b/model-lab/app/model.py
@@ -30,7 +30,9 @@ class Model:
             self.face_cascade = cv2.CascadeClassifier(
             cv2.data.haarcascades + 'haarcascade_frontalface_default.xml'
             )
-            
+            if self.face_cascade.empty():
+                raise RuntimeError("Failed to load haarcascade_frontalface_default.xml")
+
             self.net=cv2.dnn.readNetFromONNX(model_path)
     
     def detect_face(self, pil_image):

--- a/model-lab/app/requirements.txt
+++ b/model-lab/app/requirements.txt
@@ -7,3 +7,4 @@ numpy
 python-multipart
 onnxruntime
 python-dotenv
+onnx


### PR DESCRIPTION
hi @NevroHelios and @sayanChaterjee 
I have implemented the [emotion-ferplus-8 model](https://github.com/onnx/models/tree/main/validated/vision/body_analysis/emotion_ferplus), with opset version 8.
This resolves #8 

- used haarcascade from cv2 to detect face from the PIL image
- added a minimum padding to the gray scale image
- used scoremax function to generate probabilites of different emotion class

In the demo page I have added a option menu showing, the previously implemented ViT model from hugging face as well the new model. Also I have shown probabilites percentage. 

Also, there is commented out code for changing the opset version of the model.

Please review this

took reference from - https://bleedaiacademy.com/facial-expression-recognition-emotion-recognition-with-opencv/ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Demo adds a model selector (two model options) and displays per-emotion confidence probabilities with predictions.
  * Backend API now accepts a model selection and returns emotion plus per-class probabilities.

* **Documentation**
  * API docs and examples updated to show model option usage and responses including probabilities; notes for the alternative model added.

* **Chores**
  * .gitignore updated to exclude Python cache and local env dirs; requirements updated to include ONNX support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->